### PR TITLE
Having heat template generate keypair

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 To run:
 
 ```
-ssh-keygen -f id_rsa -t rsa -q -N ""
 heat stack-create -f rpc_multi_node.yml rpc -P "key_name=<keyname>;rpc_git_version=<branch/tag>" -t 150
 ```
 

--- a/rpc_multi_node.yml
+++ b/rpc_multi_node.yml
@@ -176,6 +176,16 @@ resources:
   compute2_wait_handle:
     type: "OS::Heat::SwiftSignalHandle"
 
+  ansible_keypair:
+    type: "OS::Nova::KeyPair"
+    properties:
+      name:
+        str_replace:
+          template: "%%CLUSTER_PREFIX%%-key"
+          params:
+            "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
+      save_private_key: true
+
   heat_mgmt_vxlan:
     type: Rackspace::Cloud::Network
     properties:
@@ -219,8 +229,8 @@ resources:
           params:
             "%%ID%%": "1"
             "%%EXTERNAL_VIP_IP%%": { get_attr: [controller3, accessIPv4] }
-            "%%PRIVATE_KEY%%": { get_file: id_rsa }
-            "%%PUBLIC_KEY%%": { get_file: id_rsa.pub }
+            "%%PRIVATE_KEY%%": { get_attr: [ansible_keypair, private_key] }
+            "%%PUBLIC_KEY%%": { get_attr: [ansible_keypair, public_key] }
             "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
             "%%DEPLOY_LOGGING%%": { get_param: deploy_logging }
             "%%DEPLOY_TEMPEST%%": { get_param: deploy_tempest }
@@ -264,7 +274,7 @@ resources:
           template: { get_file: config_controller_other.sh }
           params:
             "%%ID%%": "2"
-            "%%PUBLIC_KEY%%": { get_file: id_rsa.pub }
+            "%%PUBLIC_KEY%%": { get_attr: [ansible_keypair, public_key] }
             "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
             "%%DEPLOY_SWIFT%%": { get_param: deploy_swift }
             "%%CURL_CLI%%": { get_attr: ['controller2_wait_handle', 'curl_cli'] }
@@ -293,7 +303,7 @@ resources:
           template: { get_file: config_controller_other.sh }
           params:
             "%%ID%%": "3"
-            "%%PUBLIC_KEY%%": { get_file: id_rsa.pub }
+            "%%PUBLIC_KEY%%": { get_attr: [ansible_keypair, public_key] }
             "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
             "%%DEPLOY_SWIFT%%": { get_param: deploy_swift }
             "%%CURL_CLI%%": { get_attr: ['controller3_wait_handle', 'curl_cli'] }
@@ -322,7 +332,7 @@ resources:
           template: { get_file: config_compute_all.sh }
           params:
             "%%ID%%": "4"
-            "%%PUBLIC_KEY%%": { get_file: id_rsa.pub }
+            "%%PUBLIC_KEY%%": { get_attr: [ansible_keypair, public_key] }
             "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
             "%%CURL_CLI%%": { get_attr: ['compute1_wait_handle', 'curl_cli'] }
 
@@ -350,7 +360,7 @@ resources:
           template: { get_file: config_compute_all.sh }
           params:
             "%%ID%%": "5"
-            "%%PUBLIC_KEY%%": { get_file: id_rsa.pub }
+            "%%PUBLIC_KEY%%": { get_attr: [ansible_keypair, public_key] }
             "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
             "%%CURL_CLI%%": { get_attr: ['compute2_wait_handle', 'curl_cli'] }
 
@@ -370,3 +380,9 @@ outputs:
   compute2_ip:
     description: The IP address of compute2
     value: { get_attr: [compute2, accessIPv4] }
+  ansible_public_key:
+    description: Public key of generated keypair
+    value: { get_attr: [ansible_keypair, public_key] }
+  ansible_private_key:
+    description: Private key of generated keypair
+    value: { get_attr: [ansible_keypair, private_key] }


### PR DESCRIPTION
Having the heat template generate a ssh keypair instead of requiring a user
to create a ssh keypair, and using get_file to include it in the heat template.
