### PR TITLE
Change default image to PVHVM

### DIFF
--- a/rpc_multi_node.yml
+++ b/rpc_multi_node.yml
@@ -5,7 +5,7 @@ parameters:
     type: string
     label: Image name or ID
     description: Image to be used for compute instance
-    default: a3ba4cf5-70b9-4805-afa2-30d1ab81a625
+    default: Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)
 
   flavor:
     type: string


### PR DESCRIPTION
The default image (PV) yields a non functional libvirt if it ends up on
newer OpenCompute hardware in IAD. Changing to the PVHVM image solves
the issue in IAD and shouldn't effect anything in other DCs.
