### PR TITLE
Only create 1 utility container

### DIFF
--- a/openstack_user_config.yml
+++ b/openstack_user_config.yml
@@ -117,8 +117,12 @@ shared-infra_hosts:
     ip: 172.29.236.1
   __CLUSTER_PREFIX__-node2:
     ip: 172.29.236.2
+    affinity:
+      utility_container: 0
   __CLUSTER_PREFIX__-node3:
     ip: 172.29.236.3
+    affinity:
+      utility_container: 0
 
 os-infra_hosts:
   __CLUSTER_PREFIX__-node1:


### PR DESCRIPTION
We run tempest via 'ansible utility[0]', however we need to run it on
the utility container running on node1 since that's where we create the
10.1.13.1 IP.
