### PR TITLE
Add default value to gerrit_refspec parameter

### DIFF
--- a/openstack_multi_node.yml
+++ b/openstack_multi_node.yml
@@ -149,6 +149,7 @@ parameters:
   gerrit_refspec:
     type: string
     label: Git reference for the patch to test
+    default: ''
 
   run_tempest:
     type: boolean


### PR DESCRIPTION
Booting a stack manually results in the operator having to specify
gerrit_refspec, and in most cases they will not care about this.  This
commit defaults gerrit_refspec to '' so that it will not need to be
specified unless someone wishes to explicitly test a gerrit refspec.

Closes #30
