### PR TITLE
Disable tempest_compute_run_ssh

### DIFF
--- a/jenkins/stack-deploy.sh
+++ b/jenkins/stack-deploy.sh
@@ -19,6 +19,8 @@ TEMPEST_SCRIPT_PARAMETERS=${TEMPEST_SCRIPT_PARAMETERS:-"nightly_heat_multinode"}
 
 
 ssh -l root -i $SSH_KEY $SSH_OPTS $CONTROLLER1_IP "cd ${CHECKOUT} && scripts/bootstrap-ansible.sh"
+# Enabling this works for scenario tests, but generates failures when running smoke tests
+ssh -l root -i $SSH_KEY $SSH_OPTS $CONTROLLER1_IP "echo 'tempest_compute_run_ssh: False' >> /etc/openstack_deploy/user_variables.yml"
 ssh -l root -i $SSH_KEY $SSH_OPTS $CONTROLLER1_IP "export DEPLOY_LOGGING=${DEPLOY_LOGGING} DEPLOY_OPENSTACK=${DEPLOY_OPENSTACK} DEPLOY_SWIFT=${DEPLOY_SWIFT} DEPLOY_TEMPEST=${DEPLOY_TEMPEST} DEPLOY_MONITORING=${DEPLOY_MONITORING}; cd ${CHECKOUT} && ANSIBLE_FORCE_COLOR=true scripts/run-playbooks.sh"
 
 ssh -l root -i $SSH_KEY $SSH_OPTS $CONTROLLER1_IP "ifconfig br-vlan 10.1.13.1 netmask 255.255.255.0"


### PR DESCRIPTION
This commit sets tempest_compute_run_ssh to False so tempest does not
attempt to ssh into instances.  This seems to work fine on the scenario
tests we run in the gate, however it generates failures in the smoke
tests.

Closes issue #32.
