### PR TITLE
Add default value to gerrit_refspec parameter

### DIFF
--- a/rpc_multi_node.yml
+++ b/rpc_multi_node.yml
@@ -149,6 +149,7 @@ parameters:
   gerrit_refspec:
     type: string
     label: Git reference for the patch to test
+    default: ''
 
 resources:
   controller1_wait:


### PR DESCRIPTION
Booting a stack manually results in the operator having to specify
gerrit_refspec, and in most cases they will not care about this.  This
commit defaults gerrit_refspec to '' so that it will not need to be
specified unless someone wishes to explicitly test a gerrit refspec.

Closes #30

(cherry picked from commit b27c08b56c1d9fcb347f6bc58cdadf3870188b85)
