### PR TITLE
Update TEMPEST_SCRIPT_PARAMETERS

### DIFF
--- a/jenkins/stack-test.sh
+++ b/jenkins/stack-test.sh
@@ -9,7 +9,7 @@ CONTROLLER1_IP=$(heat output-show ${CLUSTER_PREFIX} controller1_ip | sed -e 's/"
 CHECKOUT="/root/os-ansible-deployment/"
 SSH_KEY=${SSH_KEY:-"~/.ssh/jenkins"}
 SSH_OPTS="-o StrictHostKeyChecking=no -o GSSAPIAuthentication=no -o HashKnownHosts=no -o UserKnownHostsFile=/dev/null"
-TEMPEST_SCRIPT_PARAMETERS=${TEMPEST_SCRIPT_PARAMETERS:-"nightly_heat_multinode"}
+TEMPEST_SCRIPT_PARAMETERS=${TEMPEST_SCRIPT_PARAMETERS:-"smoke"}
 
 
 ssh -l root -i $SSH_KEY $SSH_OPTS $CONTROLLER1_IP "export TEMPEST_SCRIPT_PARAMETERS=${TEMPEST_SCRIPT_PARAMETERS}; cd ${CHECKOUT} && scripts/run-tempest.sh"


### PR DESCRIPTION
https://review.openstack.org/#/c/165173/ changes the tempest test names
from:

commit_aio => scenario
commit_multinode => api
nightly_heat_multinode => smoke

Closes #26

This commit updates jenkins/stack-test.sh to use 'smoke' instead of
'nightly_heat_multinode'.

(cherry picked from commit 41bd95bb2cef071f9d46ab7cfbeb13964d226c9d)
