### PR TITLE
Remove all references to nightly_heat_multinode

### DIFF
--- a/jenkins/stack-deploy.sh
+++ b/jenkins/stack-deploy.sh
@@ -15,7 +15,7 @@ DEPLOY_SWIFT=${DEPLOY_SWIFT:-"no"}
 DEPLOY_TEMPEST=${DEPLOY_TEMPEST:-"no"}
 RUN_TEMPEST=${RUN_TEMPEST:-"yes"}
 DEPLOY_MONITORING=${DEPLOY_MONITORING:-"no"}
-TEMPEST_SCRIPT_PARAMETERS=${TEMPEST_SCRIPT_PARAMETERS:-"nightly_heat_multinode"}
+TEMPEST_SCRIPT_PARAMETERS=${TEMPEST_SCRIPT_PARAMETERS:-"smoke"}
 
 # Temporary work-around otherwise we hit https://bugs.launchpad.net/neutron/+bug/1382064
 # which results in tempest tests failing

--- a/rpc_multi_node.yml
+++ b/rpc_multi_node.yml
@@ -158,7 +158,7 @@ parameters:
   tempest_script_parameters:
     type: string
     label: parameters to pass to pass to run-tempest which calls openstack_tempest_gate
-    default: nightly_heat_multinode
+    default: smoke
 
 resources:
   controller1_wait:


### PR DESCRIPTION
This commit updates all references of nightly_heat_multinode to smoke.

Closes issue #35

(cherry picked from commit febf94083f5d30a6f37b9fa4d1aac1f2a910ee0b)
