### PR TITLE
Run tempest smoke tests serially

### DIFF
--- a/jenkins/stack-test.sh
+++ b/jenkins/stack-test.sh
@@ -10,6 +10,7 @@ CHECKOUT="/root/os-ansible-deployment/"
 SSH_KEY=${SSH_KEY:-"~/.ssh/jenkins"}
 SSH_OPTS="-o StrictHostKeyChecking=no -o GSSAPIAuthentication=no -o HashKnownHosts=no -o UserKnownHostsFile=/dev/null"
 TEMPEST_SCRIPT_PARAMETERS=${TEMPEST_SCRIPT_PARAMETERS:-"smoke"}
+RUN_TEMPEST_OPTS=${RUN_TEMPEST_OPTS:-'--serial'}
 
 
-ssh -l root -i $SSH_KEY $SSH_OPTS $CONTROLLER1_IP "export TEMPEST_SCRIPT_PARAMETERS=${TEMPEST_SCRIPT_PARAMETERS}; cd ${CHECKOUT} && scripts/run-tempest.sh"
+ssh -l root -i $SSH_KEY $SSH_OPTS $CONTROLLER1_IP "export TEMPEST_SCRIPT_PARAMETERS=${TEMPEST_SCRIPT_PARAMETERS} RUN_TEMPEST_OPTS=${RUN_TEMPEST_OPTS}; cd ${CHECKOUT} && scripts/run-tempest.sh"


### PR DESCRIPTION
This ensures the # of tests run is consistent and that we minimize
failures resulting in tests running in parallel.

Closes issue #43
