### PR TITLE
Set swift_proxy_vars

### DIFF
--- a/swift.yml
+++ b/swift.yml
@@ -78,10 +78,16 @@ global_overrides:
 swift-proxy_hosts:
   __CLUSTER_PREFIX__-node1:
     ip: 172.29.236.1
+    container_vars:
+      swift_proxy_vars:
   __CLUSTER_PREFIX__-node2:
     ip: 172.29.236.2
+    container_vars:
+      swift_proxy_vars:
   __CLUSTER_PREFIX__-node3:
     ip: 172.29.236.3
+    container_vars:
+      swift_proxy_vars:
 
 ## Specify the swift_hosts which will be the swift storage nodes.
 ##


### PR DESCRIPTION
Commit 5b9b49f in os-a-d assumes you have swift_proxy_vars set in your
swift.yml file.  This is presumably a bug and will need to be fixed
upstream, but in the interim we add this to our swift.yml file so that
we can get a successful deployment.

Closes issue #48
