### PR TITLE
Use general1-8 flavor by default

### DIFF
--- a/jenkins/stack-create.sh
+++ b/jenkins/stack-create.sh
@@ -5,7 +5,7 @@
 SSH_OPTS="-o StrictHostKeyChecking=no -o GSSAPIAuthentication=no -o HashKnownHosts=no"
 CLOUD_CREDS=${CLOUD_CREDS:-"~/.openrc"}
 KEY_NAME=${KEY_NAME:-"jenkins"}
-FLAVOR=${FLAVOR:-"performance1-8"}
+FLAVOR=${FLAVOR:-"general1-8"}
 OS_ANSIBLE_GIT_REPO=${OS_ANSIBLE_GIT_REPO:-"https://github.com/stackforge/os-ansible-deployment"}
 OS_ANSIBLE_GIT_VERSION=${OS_ANSIBLE_GIT_VERSION:-""}
 HEAT_GIT_REPO=${HEAT_GIT_REPO:-"https://github.com/rcbops/rpc-heat"}

--- a/openstack_multi_node.yml
+++ b/openstack_multi_node.yml
@@ -11,7 +11,7 @@ parameters:
     type: string
     label: Flavor
     description: Type of instance (flavor) to be used
-    default: performance1-8
+    default: general1-8
 
   key_name:
     type: string
@@ -260,6 +260,7 @@ resources:
         - uuid: { get_resource: heat_mgmt_vxlan }
         - uuid: { get_resource: heat_tunnel }
         - uuid: { get_resource: heat_storage }
+      diskConfig: MANUAL
       config_drive: True
       user_data_format: RAW
       user_data:
@@ -312,6 +313,7 @@ resources:
         - uuid: { get_resource: heat_mgmt_vxlan }
         - uuid: { get_resource: heat_tunnel }
         - uuid: { get_resource: heat_storage }
+      diskConfig: MANUAL
       config_drive: True
       user_data_format: RAW
       user_data:
@@ -341,6 +343,7 @@ resources:
         - uuid: { get_resource: heat_mgmt_vxlan }
         - uuid: { get_resource: heat_tunnel }
         - uuid: { get_resource: heat_storage }
+      diskConfig: MANUAL
       config_drive: True
       user_data_format: RAW
       user_data:
@@ -370,6 +373,7 @@ resources:
         - uuid: { get_resource: heat_mgmt_vxlan }
         - uuid: { get_resource: heat_tunnel }
         - uuid: { get_resource: heat_storage }
+      diskConfig: MANUAL
       config_drive: True
       user_data_format: RAW
       user_data:
@@ -398,6 +402,7 @@ resources:
         - uuid: { get_resource: heat_mgmt_vxlan }
         - uuid: { get_resource: heat_tunnel }
         - uuid: { get_resource: heat_storage }
+      diskConfig: MANUAL
       config_drive: True
       user_data_format: RAW
       user_data:


### PR DESCRIPTION
As per issue #5, performance1-8 has been deprecated in favour of
general1-8.  This commit updates references to performance1-8 to use
general1-8 instead.

Closes issue #5
