### PR TITLE
Add MaaS testing support

### DIFF
--- a/build/controller_primary.sh
+++ b/build/controller_primary.sh
@@ -10,6 +10,7 @@ DEPLOY_OPENSTACK=%%DEPLOY_OPENSTACK%%
 DEPLOY_SWIFT=%%DEPLOY_SWIFT%%
 DEPLOY_TEMPEST=%%DEPLOY_TEMPEST%%
 DEPLOY_MONITORING=%%DEPLOY_MONITORING%%
+TEST_MONITORING=%%TEST_MONITORING%%
 GERRIT_REFSPEC=%%GERRIT_REFSPEC%%
 OS_ANSIBLE_GIT_VERSION=%%OS_ANSIBLE_GIT_VERSION%%
 
@@ -91,6 +92,28 @@ pushd rpcd
   sed -i "s/\(rackspace_cloud_password\): .*/\1: %%RACKSPACE_CLOUD_PASSWORD%%/" ${config_dir}/user_extras_variables.yml
   sed -i "s/\(rackspace_cloud_api_key\): .*/\1: %%RACKSPACE_CLOUD_API_KEY%%/" ${config_dir}/user_extras_variables.yml
 
+  if [ "$DEPLOY_MONITORING" = "yes" ] && [ "$TEST_MONITORING" = "yes" ]; then
+    sed -i "s/\(ssl_check\): .*/\1: true/" ${config_dir}/user_extras_variables.yml
+    sed -i "s/\(hp_check\): .*/\1: true/" ${config_dir}/user_extras_variables.yml
+    echo "maas_horizon_scheme: https" >> ${config_dir}/user_extras_variables.yml
+    echo "\
+maas_testing_mappings:
+  - \"%%CLUSTER_PREFIX%%-node1:CONTROLLER,LOGGER,SWIFT\"
+  - \"%%CLUSTER_PREFIX%%-node2:CONTROLLER,SWIFT\"
+  - \"%%CLUSTER_PREFIX%%-node3:CONTROLLER,LOADBALANCER,SWIFT\"
+  - \"%%CLUSTER_PREFIX%%-node4:COMPUTE,BLOCK_STORAGE\"
+  - \"%%CLUSTER_PREFIX%%-node5:COMPUTE\"" >> ${config_dir}/user_extras_variables.yml
+    echo "\
+maas_testing_task_files:
+  - swift_maas
+  - maas_cdm
+  - maas_hp_hardware
+  - maas_local
+  - maas_remote
+  - maas_ssl_check
+  - network" >> ${config_dir}/user_extras_variables.yml
+  fi
+
   ${checkout_dir}/rpc-openstack/os-ansible-deployment/scripts/pw-token-gen.py --file ${config_dir}/user_extras_secrets.yml
 popd
 
@@ -101,6 +124,9 @@ if [ "%%RUN_ANSIBLE%%" = "True" ]; then
   pushd ${checkout_dir}/rpc-openstack/rpcd/playbooks
     openstack-ansible repo-build.yml
     openstack-ansible repo-pip-setup.yml
+    if [ "$DEPLOY_MONITORING" = "yes" ] && [ "$TEST_MONITORING" = "yes" ]; then
+      openstack-ansible "test-maas.yml" --tags "setup,setup-fake-hp"
+    fi
     if [ "$DEPLOY_MONITORING" = "yes" ]; then
       openstack-ansible setup-maas.yml
     fi
@@ -109,4 +135,9 @@ if [ "%%RUN_ANSIBLE%%" = "True" ]; then
     export TEMPEST_SCRIPT_PARAMETERS="%%TEMPEST_SCRIPT_PARAMETERS%%"
     scripts/run-tempest.sh
   fi
+  pushd ${checkout_dir}/rpc-openstack/rpcd/playbooks
+    if [ "$DEPLOY_MONITORING" = "yes" ] && [ "$TEST_MONITORING" = "yes" ]; then
+      openstack-ansible "test-maas.yml" --tags "test"
+    fi
+  popd
 fi

--- a/config_controller_primary.sh
+++ b/config_controller_primary.sh
@@ -180,6 +180,7 @@ DEPLOY_OPENSTACK=%%DEPLOY_OPENSTACK%%
 DEPLOY_SWIFT=%%DEPLOY_SWIFT%%
 DEPLOY_TEMPEST=%%DEPLOY_TEMPEST%%
 DEPLOY_MONITORING=%%DEPLOY_MONITORING%%
+TEST_MONITORING=%%TEST_MONITORING%%
 GERRIT_REFSPEC=%%GERRIT_REFSPEC%%
 OS_ANSIBLE_GIT_VERSION=%%OS_ANSIBLE_GIT_VERSION%%
 
@@ -261,6 +262,28 @@ pushd rpcd
   sed -i "s/\(rackspace_cloud_password\): .*/\1: %%RACKSPACE_CLOUD_PASSWORD%%/" ${config_dir}/user_extras_variables.yml
   sed -i "s/\(rackspace_cloud_api_key\): .*/\1: %%RACKSPACE_CLOUD_API_KEY%%/" ${config_dir}/user_extras_variables.yml
 
+  if [ "$DEPLOY_MONITORING" = "yes" ] && [ "$TEST_MONITORING" = "yes" ]; then
+    sed -i "s/\(ssl_check\): .*/\1: true/" ${config_dir}/user_extras_variables.yml
+    sed -i "s/\(hp_check\): .*/\1: true/" ${config_dir}/user_extras_variables.yml
+    echo "maas_horizon_scheme: https" >> ${config_dir}/user_extras_variables.yml
+    echo "\
+maas_testing_mappings:
+  - \"%%CLUSTER_PREFIX%%-node1:CONTROLLER,LOGGER,SWIFT\"
+  - \"%%CLUSTER_PREFIX%%-node2:CONTROLLER,SWIFT\"
+  - \"%%CLUSTER_PREFIX%%-node3:CONTROLLER,LOADBALANCER,SWIFT\"
+  - \"%%CLUSTER_PREFIX%%-node4:COMPUTE,BLOCK_STORAGE\"
+  - \"%%CLUSTER_PREFIX%%-node5:COMPUTE\"" >> ${config_dir}/user_extras_variables.yml
+    echo "\
+maas_testing_task_files:
+  - swift_maas
+  - maas_cdm
+  - maas_hp_hardware
+  - maas_local
+  - maas_remote
+  - maas_ssl_check
+  - network" >> ${config_dir}/user_extras_variables.yml
+  fi
+
   ${checkout_dir}/rpc-openstack/os-ansible-deployment/scripts/pw-token-gen.py --file ${config_dir}/user_extras_secrets.yml
 popd
 
@@ -271,6 +294,9 @@ if [ "%%RUN_ANSIBLE%%" = "True" ]; then
   pushd ${checkout_dir}/rpc-openstack/rpcd/playbooks
     openstack-ansible repo-build.yml
     openstack-ansible repo-pip-setup.yml
+    if [ "$DEPLOY_MONITORING" = "yes" ] && [ "$TEST_MONITORING" = "yes" ]; then
+      openstack-ansible "test-maas.yml" --tags "setup,setup-fake-hp"
+    fi
     if [ "$DEPLOY_MONITORING" = "yes" ]; then
       openstack-ansible setup-maas.yml
     fi
@@ -279,5 +305,10 @@ if [ "%%RUN_ANSIBLE%%" = "True" ]; then
     export TEMPEST_SCRIPT_PARAMETERS="%%TEMPEST_SCRIPT_PARAMETERS%%"
     scripts/run-tempest.sh
   fi
+  pushd ${checkout_dir}/rpc-openstack/rpcd/playbooks
+    if [ "$DEPLOY_MONITORING" = "yes" ] && [ "$TEST_MONITORING" = "yes" ]; then
+      openstack-ansible "test-maas.yml" --tags "test"
+    fi
+  popd
 fi
 %%CURL_CLI%% --data-binary '{"status": "SUCCESS"}'

--- a/jenkins/stack-create.sh
+++ b/jenkins/stack-create.sh
@@ -19,7 +19,8 @@ DEPLOY_LOGGING=${DEPLOY_LOGGING:-"yes"}
 DEPLOY_OPENSTACK=${DEPLOY_OPENSTACK:-"yes"}
 DEPLOY_SWIFT=${DEPLOY_SWIFT:-"yes"}
 DEPLOY_TEMPEST=${DEPLOY_TEMPEST:-"yes"}
-DEPLOY_MONITORING=${DEPLOY_MONITORING:-"no"}
+DEPLOY_MONITORING=${DEPLOY_MONITORING:-"yes"}
+TEST_MONITORING=${TEST_MONITORING:-"yes"}
 RACKSPACE_CLOUD_USERNAME=${RACKSPACE_CLOUD_USERNAME:-"$OS_USERNAME"}
 RACKSPACE_CLOUD_API_KEY=${RACKSPACE_CLOUD_API_KEY:-"$OS_API_KEY"}
 RACKSPACE_CLOUD_AUTH_URL=${RACKSPACE_CLOUD_AUTH_URL:-"$OS_AUTH_URL"}
@@ -32,7 +33,7 @@ GERRIT_REFSPEC=${GERRIT_REFSPEC:-""}
 
 source $CLOUD_CREDS
 
-heat stack-create -t 120 -f openstack_multi_node.yml ${CLUSTER_PREFIX} -P "key_name=${KEY_NAME};os_ansible_git_version=${OS_ANSIBLE_GIT_VERSION};cluster_prefix=${CLUSTER_PREFIX};deploy_logging=${DEPLOY_LOGGING};deploy_tempest=${DEPLOY_TEMPEST};deploy_swift=${DEPLOY_SWIFT};deploy_monitoring=${DEPLOY_MONITORING};rackspace_cloud_username=${RACKSPACE_CLOUD_USERNAME};rackspace_cloud_api_key=${RACKSPACE_CLOUD_API_KEY};rackspace_cloud_auth_url=${RACKSPACE_CLOUD_AUTH_URL};rackspace_cloud_password=${RACKSPACE_CLOUD_PASSWORD};rackspace_cloud_tenant_id=${RACKSPACE_CLOUD_TENANT_ID};glance_default_store=${GLANCE_DEFAULT_STORE};glance_swift_store_region=${GLANCE_SWIFT_STORE_REGION};flavor=${FLAVOR};os_ansible_git_repo=${OS_ANSIBLE_GIT_REPO};heat_git_repo=${HEAT_GIT_REPO};heat_git_version=${HEAT_GIT_VERSION};run_ansible=${RUN_ANSIBLE};gerrit_refspec=${GERRIT_REFSPEC};rpc_openstack_git_repo=${RPC_OPENSTACK_GIT_REPO};rpc_openstack_git_version=${RPC_OPENSTACK_GIT_VERSION}"
+heat stack-create -t 120 -f openstack_multi_node.yml ${CLUSTER_PREFIX} -P "key_name=${KEY_NAME};os_ansible_git_version=${OS_ANSIBLE_GIT_VERSION};cluster_prefix=${CLUSTER_PREFIX};deploy_logging=${DEPLOY_LOGGING};deploy_tempest=${DEPLOY_TEMPEST};deploy_swift=${DEPLOY_SWIFT};deploy_monitoring=${DEPLOY_MONITORING};test_monitoring=${TEST_MONITORING};rackspace_cloud_username=${RACKSPACE_CLOUD_USERNAME};rackspace_cloud_api_key=${RACKSPACE_CLOUD_API_KEY};rackspace_cloud_auth_url=${RACKSPACE_CLOUD_AUTH_URL};rackspace_cloud_password=${RACKSPACE_CLOUD_PASSWORD};rackspace_cloud_tenant_id=${RACKSPACE_CLOUD_TENANT_ID};glance_default_store=${GLANCE_DEFAULT_STORE};glance_swift_store_region=${GLANCE_SWIFT_STORE_REGION};flavor=${FLAVOR};os_ansible_git_repo=${OS_ANSIBLE_GIT_REPO};heat_git_repo=${HEAT_GIT_REPO};heat_git_version=${HEAT_GIT_VERSION};run_ansible=${RUN_ANSIBLE};gerrit_refspec=${GERRIT_REFSPEC};rpc_openstack_git_repo=${RPC_OPENSTACK_GIT_REPO};rpc_openstack_git_version=${RPC_OPENSTACK_GIT_VERSION}"
 
 exit_status=-1
 

--- a/openstack_multi_node.yml
+++ b/openstack_multi_node.yml
@@ -97,6 +97,12 @@ parameters:
     description: Deploy monitoring solution (this will only work on Rackspace Cloud Servers instances)
     default: 'yes'
 
+  test_monitoring:
+    type: string
+    label: Test monitoring solution
+    description: Test monitoring solution (this will only work on Rackspace Cloud Servers instances)
+    default: 'no'
+
   run_ansible:
     type: boolean
     label: Run ansible
@@ -278,6 +284,7 @@ resources:
             "%%TEMPEST_SCRIPT_PARAMETERS%%": { get_param: tempest_script_parameters }
             "%%DEPLOY_SWIFT%%": { get_param: deploy_swift }
             "%%DEPLOY_MONITORING%%": { get_param: deploy_monitoring }
+            "%%TEST_MONITORING%%": { get_param: test_monitoring }
             "%%OS_ANSIBLE_GIT_REPO%%": { get_param: os_ansible_git_repo }
             "%%OS_ANSIBLE_GIT_VERSION%%": { get_param: os_ansible_git_version }
             "%%HEAT_GIT_REPO%%": { get_param: heat_git_repo }


### PR DESCRIPTION
This commit enables the use of the test-maas.yml playbook being added
to rpc-openstack and makes the following changes:

The variable test_monitoring is added to the openstack_multi_node.yml
template and jenkins/stack-create.sh.

The following variables are added/modified in user_extra_variables.yml
using config_controller_primary.sh:
- ssl_check
- hp_check
- maas_horizon_scheme
- maas_testing_mappings
- maas_testing_task_files
