### PR TITLE
Selectively copy files from rcp/etc/openstack_deploy

### DIFF
--- a/build/controller_primary.sh
+++ b/build/controller_primary.sh
@@ -79,7 +79,8 @@ pushd os-ansible-deployment
 popd
 
 pushd rpcd
-  cp -a etc/openstack_deploy/* $config_dir
+  cp -a etc/openstack_deploy/{env.d/,user_extras*.yml} $config_dir
+  scripts/update-yaml.py $user_variables etc/openstack_deploy/user_variables.yml
 
   sed -i "s/\(maas_notification_plan\): .*/\1: npTechnicalContactsEmail/" ${config_dir}/user_extras_variables.yml
   # The primary IPv4 is more consistently available on access_ip1_v4 than public0_v4

--- a/config_controller_primary.sh
+++ b/config_controller_primary.sh
@@ -249,7 +249,8 @@ pushd os-ansible-deployment
 popd
 
 pushd rpcd
-  cp -a etc/openstack_deploy/* $config_dir
+  cp -a etc/openstack_deploy/{env.d/,user_extras*.yml} $config_dir
+  scripts/update-yaml.py $user_variables etc/openstack_deploy/user_variables.yml
 
   sed -i "s/\(maas_notification_plan\): .*/\1: npTechnicalContactsEmail/" ${config_dir}/user_extras_variables.yml
   # The primary IPv4 is more consistently available on access_ip1_v4 than public0_v4


### PR DESCRIPTION
rpc-openstack now includes rpc/etc/openstack_deploy/user_variables.yml,
which means we can no longer copy over all the contents of this
directory to /etc/openstack_deploy.

Closes issue #54
