### PR TITLE
Add Ceph support

### DIFF
--- a/build/all_header.sh
+++ b/build/all_header.sh
@@ -3,6 +3,8 @@
 set -e
 
 export HOME=${HOME:-"/root"}
+export DEPLOY_CEPH=%%DEPLOY_CEPH%%
+export CEPH_NODE_COUNT=%%CEPH_NODE_COUNT%%
 
 INTERFACES="/etc/network/interfaces"
 INTERFACES_D="/etc/network/interfaces.d"
@@ -21,6 +23,12 @@ cat > /etc/hosts << "EOF"
 172.29.236.4 %%CLUSTER_PREFIX%%-node4
 172.29.236.5 %%CLUSTER_PREFIX%%-node5
 EOF
+if [ $DEPLOY_CEPH == "yes" ] && [ $CEPH_NODE_COUNT -gt 0 ]; then
+  last_ceph_node=$(($CEPH_NODE_COUNT-1))
+  for x in $(seq 0 $last_ceph_node); do
+    echo "172.29.236.2$x %%CLUSTER_PREFIX%%-node2$x" >> /etc/hosts
+  done
+fi
 
 cd /root
 echo -n "%%PUBLIC_KEY%%" > .ssh/id_rsa.pub

--- a/build/controller_primary.sh
+++ b/build/controller_primary.sh
@@ -4,6 +4,9 @@ openstack_user_config="${config_dir}/openstack_user_config.yml"
 swift_config="${config_dir}/conf.d/swift.yml"
 user_variables="${config_dir}/user_variables.yml"
 user_secrets="${config_dir}/user_secrets.yml"
+ceph_config="${config_dir}/conf.d/ceph.yml"
+cinder_ceph_config="${config_dir}/conf.d/cinder_ceph.yml"
+cinder_lvm_config="${config_dir}/conf.d/cinder_lvm.yml"
 
 export DEPLOY_LOGGING=%%DEPLOY_LOGGING%%
 export DEPLOY_OPENSTACK=%%DEPLOY_OPENSTACK%%
@@ -50,6 +53,7 @@ pushd openstack-ansible
     git merge FETCH_HEAD
   fi
 
+  export ANSIBLE_ROLE_FILE="/opt/rpc-openstack/ansible-role-requirements.yml"
   scripts/bootstrap-ansible.sh
   cp -a etc/openstack_deploy /etc/
 
@@ -82,6 +86,15 @@ pushd openstack-ansible
 
     test -f $swift_config && rm $swift_config
   fi
+  if [ "$DEPLOY_CEPH" = "yes" ]; then
+    curl -o $cinder_ceph_config "${raw_url}/%%HEAT_GIT_VERSION%%/cinder_ceph.yml"
+    sed -i "s/__CLUSTER_PREFIX__/%%CLUSTER_PREFIX%%/g" $cinder_ceph_config
+    echo "cinder_ceph_client_uuid:" >> $user_secrets
+    sed -i "s/#\(nova_libvirt_images_rbd_pool\): .*/\1: vms/" $user_variables
+  else
+    curl -o $cinder_lvm_config "${raw_url}/%%HEAT_GIT_VERSION%%/cinder_lvm.yml"
+    sed -i "s/__CLUSTER_PREFIX__/%%CLUSTER_PREFIX%%/g" $cinder_lvm_config
+  fi
 
   scripts/pw-token-gen.py --file $user_secrets
 popd
@@ -99,6 +112,34 @@ pushd rpcd
   sed -i "s/\(rackspace_cloud_username\): .*/\1: %%RACKSPACE_CLOUD_USERNAME%%/" ${config_dir}/user_extras_variables.yml
   sed -i "s/\(rackspace_cloud_password\): .*/\1: %%RACKSPACE_CLOUD_PASSWORD%%/" ${config_dir}/user_extras_variables.yml
   sed -i "s/\(rackspace_cloud_api_key\): .*/\1: %%RACKSPACE_CLOUD_API_KEY%%/" ${config_dir}/user_extras_variables.yml
+  if [ "$DEPLOY_CEPH" = "yes" ]; then
+    curl -o $ceph_config "${raw_url}/%%HEAT_GIT_VERSION%%/ceph.yml"
+    last_ceph_node=$(($CEPH_NODE_COUNT-1))
+    for x in $(seq 0 $last_ceph_node); do
+      echo -e "  __CLUSTER_PREFIX__-node2$x:\n    ip: 172.29.236.2$x" >> $ceph_config
+    done
+    sed -i "s/__CLUSTER_PREFIX__/%%CLUSTER_PREFIX%%/g" $ceph_config
+    # NOTE: these are non-sensical values; we need to revisit!
+    echo "raw_multi_journal: true" | tee -a ${config_dir}/user_extras_variables.yml
+    echo "journal_size: 80000" | tee -a ${config_dir}/user_extras_variables.yml
+    echo "monitor_interface: eth1" | tee -a ${config_dir}/user_extras_variables.yml
+    echo "public_network: 172.29.236.0/22" | tee -a ${config_dir}/user_extras_variables.yml
+    echo "\
+devices:
+  - /dev/xvdc
+  - /dev/xvdf
+  - /dev/xvdg
+  - /dev/xvdh
+  - /dev/xvdi" | tee -a ${config_dir}/user_extras_variables.yml
+    echo "\
+raw_journal_devices:
+  - /dev/xvdb
+  - /dev/xvdb
+  - /dev/xvdb
+  - /dev/xvdb
+  - /dev/xvdb" | tee -a ${config_dir}/user_extras_variables.yml
+    echo "pool_default_size: 3" | tee -a ${config_dir}/user_extras_variables.yml
+  fi
 
   if [ "$DEPLOY_MONITORING" = "yes" ] && [ "$TEST_MONITORING" = "yes" ]; then
     sed -i "s/\(ssl_check\): .*/\1: true/" ${config_dir}/user_extras_variables.yml
@@ -127,25 +168,28 @@ popd
 
 # here we run ansible using the run-playbooks script in the ansible repo
 if [ "%%RUN_ANSIBLE%%" = "True" ]; then
-  cd ${checkout_dir}/rpc-openstack/openstack-ansible
-  scripts/run-playbooks.sh
-  pushd ${checkout_dir}/rpc-openstack/rpcd/playbooks
-    openstack-ansible repo-build.yml
-    openstack-ansible repo-pip-setup.yml
-    if [ "$DEPLOY_MONITORING" = "yes" ] && [ "$TEST_MONITORING" = "yes" ]; then
-      openstack-ansible "test-maas.yml" --tags "setup,setup-fake-hp"
-    fi
-    if [ "$DEPLOY_MONITORING" = "yes" ]; then
-      openstack-ansible setup-maas.yml
-    fi
+  if [ "$DEPLOY_MONITORING" = "yes" ] && [ "$TEST_MONITORING" = "yes" ]; then
+    pushd ${checkout_dir}/rpc-openstack/rpcd/playbooks
+      openstack-ansible "test-maas.yml" --tags "setup"
+    popd
+  fi
+  pushd ${checkout_dir}/rpc-openstack
+    export DEPLOY_HAPROXY="yes"
+    export DEPLOY_OSAD=$DELOY_OPENSTACK
+    export DEPLOY_ELK=$DEPLOY_LOGGING
+    export DEPLOY_MAAS=$DEPLOY_MONITORING
+    export DEPLOY_CEILOMETER="no"
+    ./scripts/deploy.sh
   popd
   if [ "%%RUN_TEMPEST%%" = "True" ]; then
-    export TEMPEST_SCRIPT_PARAMETERS="%%TEMPEST_SCRIPT_PARAMETERS%%"
-    scripts/run-tempest.sh
+    pushd ${checkout_dir}/rpc-openstack/openstack-ansible
+      export TEMPEST_SCRIPT_PARAMETERS="%%TEMPEST_SCRIPT_PARAMETERS%%"
+      scripts/run-tempest.sh
+    popd
   fi
-  pushd ${checkout_dir}/rpc-openstack/rpcd/playbooks
-    if [ "$DEPLOY_MONITORING" = "yes" ] && [ "$TEST_MONITORING" = "yes" ]; then
+  if [ "$DEPLOY_MONITORING" = "yes" ] && [ "$TEST_MONITORING" = "yes" ]; then
+    pushd ${checkout_dir}/rpc-openstack/rpcd/playbooks
       openstack-ansible "test-maas.yml" --tags "test"
-    fi
-  popd
+    popd
+  fi
 fi

--- a/ceph.yml
+++ b/ceph.yml
@@ -1,0 +1,10 @@
+---
+mons_hosts:
+  __CLUSTER_PREFIX__-node1:
+    ip: 172.29.236.1
+  __CLUSTER_PREFIX__-node2:
+    ip: 172.29.236.2
+  __CLUSTER_PREFIX__-node3:
+    ip: 172.29.236.3
+osds_hosts:
+# config_controller_primary.sh will add the OSD hosts to this file

--- a/cinder_ceph.yml
+++ b/cinder_ceph.yml
@@ -1,0 +1,47 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is the md5 of the environment file
+# this will ensure consistency when deploying.
+# User defined Storage Hosts, this should be a required group
+
+storage_hosts:
+  __CLUSTER_PREFIX__-node4:
+    ip: 172.29.236.4
+    # "container_vars" can be set outside of all other options as
+    # host specific optional variables.
+    container_vars:
+      # In this example we are defining what cinder volumes are
+      # on a given host.
+      cinder_backends:
+        # if the "limit_container_types" argument is set, within
+        # the top level key of the provided option the inventory
+        # process will perform a string match on the container name with
+        # the value found within the "limit_container_types" argument.
+        # If any part of the string found within the container
+        # name the options are appended as host_vars inside of inventory.
+        limit_container_types: cinder_volume
+        ceph_volumes:
+          volume_driver: cinder.volume.drivers.rbd.RBDDriver
+          rbd_pool: volumes
+          rbd_ceph_conf: /etc/ceph/ceph.conf
+          rbd_flatten_volume_from_snapshot: 'false'
+          rbd_max_clone_depth: 5
+          rbd_store_chunk_size: 4
+          rados_connect_timeout: -1
+          glance_api_version: 2
+          volume_backend_name: ceph_volumes
+          rbd_user: "{{ cinder_ceph_client }}"
+          rbd_secret_uuid: "{{ cinder_ceph_client_uuid }}"

--- a/cinder_lvm.yml
+++ b/cinder_lvm.yml
@@ -1,0 +1,39 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is the md5 of the environment file
+# this will ensure consistency when deploying.
+# User defined Storage Hosts, this should be a required group
+
+storage_hosts:
+  __CLUSTER_PREFIX__-node4:
+    ip: 172.29.236.4
+    # "container_vars" can be set outside of all other options as
+    # host specific optional variables.
+    container_vars:
+      # In this example we are defining what cinder volumes are
+      # on a given host.
+      cinder_backends:
+        # if the "limit_container_types" argument is set, within
+        # the top level key of the provided option the inventory
+        # process will perform a string match on the container name with
+        # the value found within the "limit_container_types" argument.
+        # If any part of the string found within the container
+        # name the options are appended as host_vars inside of inventory.
+        limit_container_types: cinder_volume
+        lvm:
+          volume_group: cinder-volumes
+          volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+          volume_backend_name: LVM_iSCSI

--- a/config_compute_all.sh
+++ b/config_compute_all.sh
@@ -3,6 +3,8 @@
 set -e
 
 export HOME=${HOME:-"/root"}
+export DEPLOY_CEPH=%%DEPLOY_CEPH%%
+export CEPH_NODE_COUNT=%%CEPH_NODE_COUNT%%
 
 INTERFACES="/etc/network/interfaces"
 INTERFACES_D="/etc/network/interfaces.d"
@@ -21,6 +23,12 @@ cat > /etc/hosts << "EOF"
 172.29.236.4 %%CLUSTER_PREFIX%%-node4
 172.29.236.5 %%CLUSTER_PREFIX%%-node5
 EOF
+if [ $DEPLOY_CEPH == "yes" ] && [ $CEPH_NODE_COUNT -gt 0 ]; then
+  last_ceph_node=$(($CEPH_NODE_COUNT-1))
+  for x in $(seq 0 $last_ceph_node); do
+    echo "172.29.236.2$x %%CLUSTER_PREFIX%%-node2$x" >> /etc/hosts
+  done
+fi
 
 cd /root
 echo -n "%%PUBLIC_KEY%%" > .ssh/id_rsa.pub

--- a/config_controller_other.sh
+++ b/config_controller_other.sh
@@ -3,6 +3,8 @@
 set -e
 
 export HOME=${HOME:-"/root"}
+export DEPLOY_CEPH=%%DEPLOY_CEPH%%
+export CEPH_NODE_COUNT=%%CEPH_NODE_COUNT%%
 
 INTERFACES="/etc/network/interfaces"
 INTERFACES_D="/etc/network/interfaces.d"
@@ -21,6 +23,12 @@ cat > /etc/hosts << "EOF"
 172.29.236.4 %%CLUSTER_PREFIX%%-node4
 172.29.236.5 %%CLUSTER_PREFIX%%-node5
 EOF
+if [ $DEPLOY_CEPH == "yes" ] && [ $CEPH_NODE_COUNT -gt 0 ]; then
+  last_ceph_node=$(($CEPH_NODE_COUNT-1))
+  for x in $(seq 0 $last_ceph_node); do
+    echo "172.29.236.2$x %%CLUSTER_PREFIX%%-node2$x" >> /etc/hosts
+  done
+fi
 
 cd /root
 echo -n "%%PUBLIC_KEY%%" > .ssh/id_rsa.pub

--- a/jenkins/stack-create.sh
+++ b/jenkins/stack-create.sh
@@ -18,6 +18,11 @@ DEPLOY_LB=${DEPLOY_HOST:-"yes"}
 DEPLOY_LOGGING=${DEPLOY_LOGGING:-"yes"}
 DEPLOY_OPENSTACK=${DEPLOY_OPENSTACK:-"yes"}
 DEPLOY_SWIFT=${DEPLOY_SWIFT:-"yes"}
+DEPLOY_CEPH=${DEPLOY_CEPH:-"no"}
+CEPH_NODE_COUNT=${CEPH_NODE_COUNT:-"0"}
+if [ $DEPLOY_CEPH == "yes" ] && [ $CEPH_NODE_COUNT -lt 1 ]; then
+  CEPH_NODE_COUNT=1
+fi
 DEPLOY_TEMPEST=${DEPLOY_TEMPEST:-"yes"}
 DEPLOY_MONITORING=${DEPLOY_MONITORING:-"yes"}
 TEST_MONITORING=${TEST_MONITORING:-"yes"}
@@ -27,13 +32,16 @@ RACKSPACE_CLOUD_AUTH_URL=${RACKSPACE_CLOUD_AUTH_URL:-"$OS_AUTH_URL"}
 RACKSPACE_CLOUD_PASSWORD=${RACKSPACE_CLOUD_PASSWORD:-"$OS_PASSWORD"}
 RACKSPACE_CLOUD_TENANT_ID=${RACKSPACE_CLOUD_TENANT_ID:-"$OS_TENANT_ID"}
 GLANCE_DEFAULT_STORE=${GLANCE_DEFAULT_STORE:-"swift"}
+if [ $DEPLOY_CEPH == "yes" ]; then
+  GLANCE_DEFAULT_STORE="rbd"
+fi
 GLANCE_SWIFT_STORE_REGION=${GLANCE_SWIFT_STORE_REGION:-"DFW"}
 RUN_ANSIBLE=${RUN_ANSIBLE:-"no"}
 GERRIT_REFSPEC=${GERRIT_REFSPEC:-""}
 
 source $CLOUD_CREDS
 
-heat stack-create -t 120 -f openstack_multi_node.yml ${CLUSTER_PREFIX} -P "key_name=${KEY_NAME};os_ansible_git_version=${OS_ANSIBLE_GIT_VERSION};cluster_prefix=${CLUSTER_PREFIX};deploy_logging=${DEPLOY_LOGGING};deploy_tempest=${DEPLOY_TEMPEST};deploy_swift=${DEPLOY_SWIFT};deploy_monitoring=${DEPLOY_MONITORING};test_monitoring=${TEST_MONITORING};rackspace_cloud_username=${RACKSPACE_CLOUD_USERNAME};rackspace_cloud_api_key=${RACKSPACE_CLOUD_API_KEY};rackspace_cloud_auth_url=${RACKSPACE_CLOUD_AUTH_URL};rackspace_cloud_password=${RACKSPACE_CLOUD_PASSWORD};rackspace_cloud_tenant_id=${RACKSPACE_CLOUD_TENANT_ID};glance_default_store=${GLANCE_DEFAULT_STORE};glance_swift_store_region=${GLANCE_SWIFT_STORE_REGION};flavor=${FLAVOR};os_ansible_git_repo=${OS_ANSIBLE_GIT_REPO};heat_git_repo=${HEAT_GIT_REPO};heat_git_version=${HEAT_GIT_VERSION};run_ansible=${RUN_ANSIBLE};gerrit_refspec=${GERRIT_REFSPEC};rpc_openstack_git_repo=${RPC_OPENSTACK_GIT_REPO};rpc_openstack_git_version=${RPC_OPENSTACK_GIT_VERSION}"
+heat stack-create -e openstack_multi_node_environment.yml -t 120 -f openstack_multi_node.yml ${CLUSTER_PREFIX} -P "key_name=${KEY_NAME};os_ansible_git_version=${OS_ANSIBLE_GIT_VERSION};cluster_prefix=${CLUSTER_PREFIX};deploy_logging=${DEPLOY_LOGGING};deploy_tempest=${DEPLOY_TEMPEST};deploy_swift=${DEPLOY_SWIFT};deploy_ceph=${DEPLOY_CEPH};ceph_node_count=${CEPH_NODE_COUNT};deploy_monitoring=${DEPLOY_MONITORING};test_monitoring=${TEST_MONITORING};rackspace_cloud_username=${RACKSPACE_CLOUD_USERNAME};rackspace_cloud_api_key=${RACKSPACE_CLOUD_API_KEY};rackspace_cloud_auth_url=${RACKSPACE_CLOUD_AUTH_URL};rackspace_cloud_password=${RACKSPACE_CLOUD_PASSWORD};rackspace_cloud_tenant_id=${RACKSPACE_CLOUD_TENANT_ID};glance_default_store=${GLANCE_DEFAULT_STORE};glance_swift_store_region=${GLANCE_SWIFT_STORE_REGION};flavor=${FLAVOR};os_ansible_git_repo=${OS_ANSIBLE_GIT_REPO};heat_git_repo=${HEAT_GIT_REPO};heat_git_version=${HEAT_GIT_VERSION};run_ansible=${RUN_ANSIBLE};gerrit_refspec=${GERRIT_REFSPEC};rpc_openstack_git_repo=${RPC_OPENSTACK_GIT_REPO};rpc_openstack_git_version=${RPC_OPENSTACK_GIT_VERSION}"
 
 exit_status=-1
 

--- a/openstack_multi_node.yml
+++ b/openstack_multi_node.yml
@@ -79,6 +79,20 @@ parameters:
     description: Deploy openstack playbooks
     default: 'yes'
 
+  deploy_ceph:
+    type: string
+    label: Deploy Ceph
+    description: Deploy Ceph
+    default: 'no'
+
+  ceph_node_count:
+    type: number
+    label: Number of Ceph nodes to create
+    description: Number of Ceph nodes to create
+    default: 0
+    constraints:
+      - range: { min: 0, max: 10 }
+
   deploy_swift:
     type: string
     label: Deploy swift
@@ -150,7 +164,7 @@ parameters:
     description: The storage backend to configure glance with
     default: swift
     constraints:
-      - allowed_values: [ swift, file ]
+      - allowed_values: [ swift, file, rbd ]
 
   glance_swift_store_region:
     type: string
@@ -283,6 +297,8 @@ resources:
             "%%RUN_TEMPEST%%": { get_param: run_tempest }
             "%%TEMPEST_SCRIPT_PARAMETERS%%": { get_param: tempest_script_parameters }
             "%%DEPLOY_SWIFT%%": { get_param: deploy_swift }
+            "%%DEPLOY_CEPH%%": { get_param: deploy_ceph }
+            "%%CEPH_NODE_COUNT%%": { get_param: ceph_node_count }
             "%%DEPLOY_MONITORING%%": { get_param: deploy_monitoring }
             "%%TEST_MONITORING%%": { get_param: test_monitoring }
             "%%OS_ANSIBLE_GIT_REPO%%": { get_param: os_ansible_git_repo }
@@ -329,6 +345,8 @@ resources:
             "%%PUBLIC_KEY%%": { get_attr: [ansible_keypair, public_key] }
             "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
             "%%DEPLOY_SWIFT%%": { get_param: deploy_swift }
+            "%%DEPLOY_CEPH%%": { get_param: deploy_ceph }
+            "%%CEPH_NODE_COUNT%%": { get_param: ceph_node_count }
             "%%CURL_CLI%%": { get_attr: ['controller2_wait_handle', 'curl_cli'] }
 
   controller3:
@@ -358,6 +376,8 @@ resources:
             "%%PUBLIC_KEY%%": { get_attr: [ansible_keypair, public_key] }
             "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
             "%%DEPLOY_SWIFT%%": { get_param: deploy_swift }
+            "%%DEPLOY_CEPH%%": { get_param: deploy_ceph }
+            "%%CEPH_NODE_COUNT%%": { get_param: ceph_node_count }
             "%%CURL_CLI%%": { get_attr: ['controller3_wait_handle', 'curl_cli'] }
 
   compute1:
@@ -386,6 +406,8 @@ resources:
             "%%ID%%": "4"
             "%%PUBLIC_KEY%%": { get_attr: [ansible_keypair, public_key] }
             "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
+            "%%DEPLOY_CEPH%%": { get_param: deploy_ceph }
+            "%%CEPH_NODE_COUNT%%": { get_param: ceph_node_count }
             "%%CURL_CLI%%": { get_attr: ['compute1_wait_handle', 'curl_cli'] }
 
   compute2:
@@ -414,7 +436,29 @@ resources:
             "%%ID%%": "5"
             "%%PUBLIC_KEY%%": { get_attr: [ansible_keypair, public_key] }
             "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
+            "%%DEPLOY_CEPH%%": { get_param: deploy_ceph }
+            "%%CEPH_NODE_COUNT%%": { get_param: ceph_node_count }
             "%%CURL_CLI%%": { get_attr: ['compute2_wait_handle', 'curl_cli'] }
+
+  ceph_nodes:
+    type: 'OS::Heat::ResourceGroup'
+    properties:
+      count: { get_param: ceph_node_count }
+      resource_def:
+        type: 'RPC::Server::WithVolumes'
+        properties:
+          image: { get_param: image }
+          flavor: { get_param: flavor }
+          key_name: { get_param: key_name }
+          cluster_prefix: { get_param: cluster_prefix }
+          deploy_ceph: { get_param: deploy_ceph }
+          ceph_node_count: { get_param: ceph_node_count }
+          public_key: { get_attr: [ansible_keypair, public_key] }
+          group_index: '%index%'
+          heat_mgmt_vxlan: { get_resource: heat_mgmt_vxlan }
+          heat_tunnel: { get_resource: heat_tunnel }
+          heat_storage: { get_resource: heat_storage }
+          volume_size: 400
 
 outputs:
   controller1_ip:
@@ -432,3 +476,6 @@ outputs:
   compute2_ip:
     description: The IP address of compute2
     value: { get_attr: [compute2, accessIPv4] }
+  ceph_nodes_ip:
+    description: The IP address of ceph1
+    value: { get_attr: [ceph_nodes, accessIPv4] }

--- a/openstack_multi_node_environment.yml
+++ b/openstack_multi_node_environment.yml
@@ -1,0 +1,3 @@
+resource_registry:
+  RPC::Server::WithVolumes: server_with_volumes.yaml
+  RPC::Volume::WithAttachment: volume_with_attachment.yaml

--- a/openstack_user_config.yml
+++ b/openstack_user_config.yml
@@ -164,28 +164,6 @@ compute_hosts:
   __CLUSTER_PREFIX__-node5:
     ip: 172.29.236.5
 
-# User defined Storage Hosts, this should be a required group
-storage_hosts:
-  __CLUSTER_PREFIX__-node4:
-    ip: 172.29.236.4
-    # "container_vars" can be set outside of all other options as
-    # host specific optional variables.
-    container_vars:
-      # In this example we are defining what cinder volumes are
-      # on a given host.
-      cinder_backends:
-        # if the "limit_container_types" argument is set, within
-        # the top level key of the provided option the inventory
-        # process will perform a string match on the container name with
-        # the value found within the "limit_container_types" argument.
-        # If any part of the string found within the container
-        # name the options are appended as host_vars inside of inventory.
-        limit_container_types: cinder_volume
-        lvm:
-          volume_group: cinder-volumes
-          volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
-          volume_backend_name: LVM_iSCSI
-
 # User defined Logging Hosts, this should be a required group
 log_hosts:
   __CLUSTER_PREFIX__-node1:

--- a/server_with_volumes.yaml
+++ b/server_with_volumes.yaml
@@ -1,0 +1,117 @@
+heat_template_version: 2013-05-23
+
+parameters:
+  image:
+    type: string
+    label: Image name or ID
+    description: Image to be used for compute instance
+    default: Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)
+
+  flavor:
+    type: string
+    label: Flavor
+    description: Type of instance (flavor) to be used
+    default: performance1-8
+
+  key_name:
+    type: string
+    label: Key name
+    description: Name of key-pair to be used for compute instance
+    default: default
+
+  volume_size:
+    type: number
+    description: Size of volume to attach to instance
+    default: 100
+
+  cluster_prefix:
+    type: string
+    label: Cluster prefix
+    description: Prefix to use when building cluster
+    default: heat
+    constraints:
+      # The recommended hostname length should be less than 20 chars, we tack
+      # on -nodeX which adds up to another 5 chars, hence max being 14.
+      - length: { min: 1, max: 14 }
+
+  deploy_ceph:
+    type: string
+    label: Deploy Ceph
+    description: Deploy Ceph
+    default: 'no'
+
+  ceph_node_count:
+    type: number
+    label: Number of Ceph nodes to create
+    description: Number of Ceph nodes to create
+    default: 0
+    constraints:
+      - range: { min: 0, max: 10 }
+
+  group_index:
+    type: string
+    default: "0"
+
+  public_key:
+    type: string
+
+  heat_mgmt_vxlan:
+    type: string
+
+  heat_tunnel:
+    type: string
+
+  heat_storage:
+    type: string
+
+resources:
+  ceph_node_wait:
+    type: "OS::Heat::SwiftSignal"
+    properties:
+      handle: { get_resource: ceph_node_wait_handle }
+      count: 1
+      timeout: 900
+
+  ceph_node_wait_handle:
+    type: "OS::Heat::SwiftSignalHandle"
+
+  ceph_node:
+    type: "OS::Nova::Server"
+    properties:
+      image: { get_param: image }
+      flavor: { get_param: flavor }
+      key_name: { get_param: key_name }
+      name:
+        str_replace:
+          template: "%%CLUSTER_PREFIX%%-node2%group_index%"
+          params:
+            "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
+            "%group_index%": { get_param: group_index }
+      networks:
+        - uuid: 00000000-0000-0000-0000-000000000000
+        - uuid: 11111111-1111-1111-1111-111111111111
+        - uuid: { get_param: heat_mgmt_vxlan }
+        - uuid: { get_param: heat_tunnel }
+        - uuid: { get_param: heat_storage }
+      config_drive: True
+      user_data_format: RAW
+      user_data:
+        str_replace:
+          template: { get_file: config_compute_all.sh }
+          params:
+            "%%ID%%": { list_join: ["", ["2", { get_param: group_index }]] }
+            "%%PUBLIC_KEY%%": { get_param: public_key }
+            "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
+            "%%DEPLOY_CEPH%%": { get_param: deploy_ceph }
+            "%%CEPH_NODE_COUNT%%": { get_param: ceph_node_count }
+            "%%CURL_CLI%%": { get_attr: ['ceph_node_wait_handle', 'curl_cli'] }
+
+  ceph_node_volumes:
+    type: 'OS::Heat::ResourceGroup'
+    properties:
+      count: 6
+      resource_def:
+        type: 'RPC::Volume::WithAttachment'
+        properties:
+          instance_id: { get_resource: ceph_node }
+          volume_size: { get_param: volume_size }

--- a/volume_with_attachment.yaml
+++ b/volume_with_attachment.yaml
@@ -1,0 +1,25 @@
+# Adapted from https://raw.githubusercontent.com/openstack/heat-templates/master/hot/resource_group/volume_with_attachment.yaml
+heat_template_version: 2013-05-23
+
+parameters:
+  volume_size:
+    type: number
+    description: Size of volume to attach to instance
+    default: 100
+
+  instance_id:
+    type: string
+    description: Server to attach volume to
+
+resources:
+  volume:
+    type: OS::Cinder::Volume
+    properties:
+      size: { get_param: volume_size }
+      description: Volume for stack
+
+  volume_attachment:
+    type: OS::Cinder::VolumeAttachment
+    properties:
+      volume_id: { get_resource: volume }
+      instance_uuid: { get_param: instance_id}


### PR DESCRIPTION
This commit adds support for deploying a Ceph cluster and enabling it
for nova, cinder and glance. The variables DEPLOY_CEPH and
CEPH_NODE_COUNT have been introduced. When DEPLOY_CEPH == 'yes'
additional nodes are created as OSDs. The number is determined by
CEPH_NODE_COUNT and defaults to 1 when DEPLOY_CEPH == 'yes' and 0
otherwise.

controller_primary.sh has been modified to use the deploy.sh script in
rpc-openstack instead of run-playbooks.sh in os-ansible-deployment. This
was done because the ceph playbook needs to be run partway through the
run-playbook.sh script and the deploy.sh script has already done the
work to break this out.
