### PR TITLE
Temporarily disable snet

### DIFF
--- a/rpc_user_config.yml
+++ b/rpc_user_config.yml
@@ -76,15 +76,17 @@ global_overrides:
         container_bridge: "br-storage"
         container_interface: "eth2"
         ip_from_q: "storage"
-    - network:
-        group_binds:
-          - glance_api
-          - nova_compute
-          - neutron_linuxbridge_agent
-        type: "raw"
-        container_bridge: "br-snet"
-        container_interface: "eth3"
-        ip_from_q: "snet"
+    # br-snet temporarily disabled due to bug in public cloud heat/neutron
+    # services that causes service net to not get assigned an interface
+    #- network:
+    #    group_binds:
+    #      - glance_api
+    #      - nova_compute
+    #      - neutron_linuxbridge_agent
+    #    type: "raw"
+    #    container_bridge: "br-snet"
+    #    container_interface: "eth3"
+    #    ip_from_q: "snet"
     - network:
         group_binds:
           - neutron_linuxbridge_agent


### PR DESCRIPTION
There is a bug in public cloud heat/neutron services that causes the
service net to not be assigned an interface when one is explicitly
requested (versus getting it by default when no interfaces are
explicitly requested, which does work fine).
