### PR TITLE
Run test-maas.yml in rpc-heat jenkins gate

### DIFF
--- a/jenkins/stack-monitoring.sh
+++ b/jenkins/stack-monitoring.sh
@@ -10,14 +10,20 @@ CHECKOUT="/opt/rpc-openstack/"
 SSH_KEY=${SSH_KEY:-"~/.ssh/jenkins"}
 SSH_OPTS="-o StrictHostKeyChecking=no -o GSSAPIAuthentication=no -o HashKnownHosts=no -o UserKnownHostsFile=/dev/null"
 DEPLOY_MONITORING=${DEPLOY_MONITORING:-"no"}
+TEST_MONITORING=${TEST_MONITORING:-"no"}
 
 
 if [ $DEPLOY_MONITORING = "yes" ]; then
   ssh -l root -i $SSH_KEY $SSH_OPTS $CONTROLLER1_IP "cd ${CHECKOUT}/rpcd/playbooks && openstack-ansible repo-build.yml"
   ssh -l root -i $SSH_KEY $SSH_OPTS $CONTROLLER1_IP "cd ${CHECKOUT}/rpcd/playbooks && openstack-ansible repo-pip-setup.yml"
+  # We setup test-maas.yml first so we get the mocked hp tools dropped on the
+  # hosts; this prevents us from getting hp-related failures until the tools
+  # are dropped.
+  if [ "$TEST_MONITORING" = "yes" ]; then
+    ssh -l root -i $SSH_KEY $SSH_OPTS $CONTROLLER1_IP "cd ${CHECKOUT}/rpcd/playbooks && openstack-ansible test-maas.yml --tags setup,setup-fake-hp"
+  fi
   ssh -l root -i $SSH_KEY $SSH_OPTS $CONTROLLER1_IP "cd ${CHECKOUT}/rpcd/playbooks && openstack-ansible setup-maas.yml"
-  echo "Testing MaaS checks ..."
-  scp -i $SSH_KEY $SSH_OPTS jenkins/rpc-maas-tool.py root@${CONTROLLER1_IP}:${CHECKOUT}/scripts
-  ssh -l root -i $SSH_KEY $SSH_OPTS $CONTROLLER1_IP "cd ${CHECKOUT}/scripts && python rpc-maas-tool.py check --prefix ${CLUSTER_PREFIX}"
-  echo "Done."
+  if [ "$TEST_MONITORING" = "yes" ]; then
+    ssh -l root -i $SSH_KEY $SSH_OPTS $CONTROLLER1_IP "cd ${CHECKOUT}/rpcd/playbooks && openstack-ansible test-maas.yml --tags test"
+  fi
 fi


### PR DESCRIPTION
Currently, we test MaaS using rpc-maas-tool.py.  This commit updates
stack-monitoring.sh to use test-maas.yml instead.
