### PR TITLE
Account for namespace change in upstream

### DIFF
--- a/build/controller_primary.sh
+++ b/build/controller_primary.sh
@@ -1,28 +1,29 @@
 rpc_user_config="/etc/rpc_deploy/rpc_user_config.yml"
 swift_config="/etc/rpc_deploy/conf.d/swift.yml"
 user_variables="/etc/rpc_deploy/user_variables.yml"
+clone_dir="/opt/openstack-ansible"
 
-DEPLOY_INFRASTRUCTURE=%%DEPLOY_INFRASTRUCTURE%%
-DEPLOY_LOGGING=%%DEPLOY_LOGGING%%
-DEPLOY_OPENSTACK=%%DEPLOY_OPENSTACK%%
-DEPLOY_SWIFT=%%DEPLOY_SWIFT%%
-DEPLOY_TEMPEST=%%DEPLOY_TEMPEST%%
-DEPLOY_MONITORING=%%DEPLOY_MONITORING%%
-GERRIT_REFSPEC=%%GERRIT_REFSPEC%%
+export DEPLOY_INFRASTRUCTURE=%%DEPLOY_INFRASTRUCTURE%%
+export DEPLOY_LOGGING=%%DEPLOY_LOGGING%%
+export DEPLOY_OPENSTACK=%%DEPLOY_OPENSTACK%%
+export DEPLOY_SWIFT=%%DEPLOY_SWIFT%%
+export DEPLOY_TEMPEST=%%DEPLOY_TEMPEST%%
+export DEPLOY_MONITORING=%%DEPLOY_MONITORING%%
+export GERRIT_REFSPEC=%%GERRIT_REFSPEC%%
 
 echo -n "%%PRIVATE_KEY%%" > .ssh/id_rsa
 chmod 600 .ssh/*
 
-if [ ! -e /root/os-ansible-deployment ]; then
-  git clone -b %%OS_ANSIBLE_GIT_VERSION%% %%OS_ANSIBLE_GIT_REPO%% os-ansible-deployment
+if [ ! -e $clone_dir ]; then
+  git clone -b %%OS_ANSIBLE_GIT_VERSION%% %%OS_ANSIBLE_GIT_REPO%% $clone_dir
 fi
 
-cd os-ansible-deployment
+cd $clone_dir
 if [ ! -z $GERRIT_REFSPEC ]; then
   # Git creates a commit while merging so identity must be set.
   git config --global user.name "Hot Hot Heat"
   git config --global user.email "flaming@li.ps"
-  git fetch https://review.openstack.org/stackforge/os-ansible-deployment $GERRIT_REFSPEC
+  git fetch https://review.openstack.org/openstack/openstack-ansible $GERRIT_REFSPEC
   git merge FETCH_HEAD
 fi
 pip install -r requirements.txt
@@ -67,7 +68,7 @@ else
   test -f $swift_config && rm $swift_config
 fi
 
-cd /root/os-ansible-deployment
+cd $clone_dir
 
 # here we run ansible using the run-playbooks script in the ansible repo
 if [ "%%RUN_ANSIBLE%%" = "True" ]; then

--- a/config_controller_primary.sh
+++ b/config_controller_primary.sh
@@ -171,6 +171,7 @@ fi
 rpc_user_config="/etc/rpc_deploy/rpc_user_config.yml"
 swift_config="/etc/rpc_deploy/conf.d/swift.yml"
 user_variables="/etc/rpc_deploy/user_variables.yml"
+clone_dir="/opt/openstack-ansible"
 
 export DEPLOY_INFRASTRUCTURE=%%DEPLOY_INFRASTRUCTURE%%
 export DEPLOY_LOGGING=%%DEPLOY_LOGGING%%
@@ -183,16 +184,16 @@ export GERRIT_REFSPEC=%%GERRIT_REFSPEC%%
 echo -n "%%PRIVATE_KEY%%" > .ssh/id_rsa
 chmod 600 .ssh/*
 
-if [ ! -e /root/os-ansible-deployment ]; then
-  git clone -b %%OS_ANSIBLE_GIT_VERSION%% %%OS_ANSIBLE_GIT_REPO%% os-ansible-deployment
+if [ ! -e $clone_dir ]; then
+  git clone -b %%OS_ANSIBLE_GIT_VERSION%% %%OS_ANSIBLE_GIT_REPO%% $clone_dir
 fi
 
-cd os-ansible-deployment
+cd $clone_dir
 if [ ! -z $GERRIT_REFSPEC ]; then
   # Git creates a commit while merging so identity must be set.
   git config --global user.name "Hot Hot Heat"
   git config --global user.email "flaming@li.ps"
-  git fetch https://review.openstack.org/stackforge/os-ansible-deployment $GERRIT_REFSPEC
+  git fetch https://review.openstack.org/openstack/openstack-ansible $GERRIT_REFSPEC
   git merge FETCH_HEAD
 fi
 pip install -r requirements.txt
@@ -237,7 +238,7 @@ else
   test -f $swift_config && rm $swift_config
 fi
 
-cd /root/os-ansible-deployment
+cd $clone_dir
 
 # here we run ansible using the run-playbooks script in the ansible repo
 if [ "%%RUN_ANSIBLE%%" = "True" ]; then

--- a/jenkins/stack-create.sh
+++ b/jenkins/stack-create.sh
@@ -6,7 +6,7 @@ SSH_OPTS="-o StrictHostKeyChecking=no -o GSSAPIAuthentication=no -o HashKnownHos
 CLOUD_CREDS=${CLOUD_CREDS:-"~/.openrc"}
 KEY_NAME=${KEY_NAME:-"jenkins"}
 FLAVOR=${FLAVOR:-"performance1-8"}
-OS_ANSIBLE_GIT_REPO=${OS_ANSIBLE_GIT_REPO:-"https://github.com/stackforge/os-ansible-deployment"}
+OS_ANSIBLE_GIT_REPO=${OS_ANSIBLE_GIT_REPO:-"https://github.com/openstack/openstack-ansible"}
 OS_ANSIBLE_GIT_VERSION=${OS_ANSIBLE_GIT_VERSION:-"master"}
 HEAT_GIT_REPO=${HEAT_GIT_REPO:-"https://github.com/rcbops/rpc-heat"}
 HEAT_GIT_VERSION=${HEAT_GIT_VERSION:-"master"}

--- a/jenkins/stack-deploy.sh
+++ b/jenkins/stack-deploy.sh
@@ -6,7 +6,7 @@ CLOUD_CREDS=${CLOUD_CREDS:-"~/.openrc"}
 source $CLOUD_CREDS
 
 CONTROLLER1_IP=$(heat output-show ${CLUSTER_PREFIX} controller1_ip | sed -e 's/"//g')
-CHECKOUT="/root/os-ansible-deployment/"
+CHECKOUT="/opt/openstack-ansible/"
 SSH_KEY=${SSH_KEY:-"~/.ssh/jenkins"}
 SSH_OPTS="-o StrictHostKeyChecking=no -o GSSAPIAuthentication=no -o HashKnownHosts=no -o UserKnownHostsFile=/dev/null"
 DEPLOY_LOGGING=${DEPLOY_LOGGING:-"yes"}

--- a/jenkins/stack-test.sh
+++ b/jenkins/stack-test.sh
@@ -6,7 +6,7 @@ CLOUD_CREDS=${CLOUD_CREDS:-"~/.openrc"}
 source $CLOUD_CREDS
 
 CONTROLLER1_IP=$(heat output-show ${CLUSTER_PREFIX} controller1_ip | sed -e 's/"//g')
-CHECKOUT="/root/os-ansible-deployment/"
+CHECKOUT="/opt/openstack-ansible/"
 SSH_KEY=${SSH_KEY:-"~/.ssh/jenkins"}
 SSH_OPTS="-o StrictHostKeyChecking=no -o GSSAPIAuthentication=no -o HashKnownHosts=no -o UserKnownHostsFile=/dev/null"
 TEMPEST_SCRIPT_PARAMETERS=${TEMPEST_SCRIPT_PARAMETERS:-"smoke"}

--- a/rpc_multi_node.yml
+++ b/rpc_multi_node.yml
@@ -23,7 +23,7 @@ parameters:
     type: string
     label: RPC git repo
     description: URL of RPC git repo to clone
-    default: https://github.com/stackforge/os-ansible-deployment
+    default: https://github.com/openstack/openstack-ansible
 
   os_ansible_git_version:
     type: string


### PR DESCRIPTION
stackforge/os-ansible-deployment has moved to
openstack/openstack-ansible, so we account for that move here.

Additionally, we move the checkout/clone location from
/root/os-ansible-deployment to /opt/openstack-ansible

Fixes #73
