### PR TITLE
Lower keystone_wsgi_processes

### DIFF
--- a/build/controller_primary.sh
+++ b/build/controller_primary.sh
@@ -58,6 +58,7 @@ pushd openstack-ansible
   cp -a etc/openstack_deploy /etc/
 
   echo "nova_virt_type: qemu" >> $user_variables
+  echo "keystone_wsgi_processes: 4" >> $user_variables
   sed -i "s/\(glance_default_store\): .*/\1: %%GLANCE_DEFAULT_STORE%%/g" $user_variables
 
   environment_version=$(md5sum ${config_dir}/openstack_environment.yml | awk '{print $1}')

--- a/config_controller_primary.sh
+++ b/config_controller_primary.sh
@@ -245,6 +245,7 @@ pushd openstack-ansible
   cp -a etc/openstack_deploy /etc/
 
   echo "nova_virt_type: qemu" >> $user_variables
+  echo "keystone_wsgi_processes: 4" >> $user_variables
   sed -i "s/\(glance_default_store\): .*/\1: %%GLANCE_DEFAULT_STORE%%/g" $user_variables
 
   environment_version=$(md5sum ${config_dir}/openstack_environment.yml | awk '{print $1}')


### PR DESCRIPTION
Currently, keystone_wsgi_processes is being set to 16 which is causing
keystone to consume too much memory.  This commit sets
keystone_wsgi_processes to 4 which is the same value we use in the
gate.

Closes issue #78
