### PR TITLE
Change how we override %%OS_ANSIBLE_GIT_VERSION%%

### DIFF
--- a/build/controller_primary.sh
+++ b/build/controller_primary.sh
@@ -31,9 +31,7 @@ cd ${checkout_dir}/rpc-openstack
 
 # if we want to use a different submodule repo/sha
 if [ ! -z $OS_ANSIBLE_GIT_VERSION ]; then
-  rm .gitmodules
-  git rm openstack-ansible
-  git submodule add %%OS_ANSIBLE_GIT_REPO%%
+  sed -i 's@url = https://git.openstack.org/openstack/openstack-ansible@url = %%OS_ANSIBLE_GIT_REPO%%@' .gitmodules
   git submodule update --init
   pushd openstack-ansible
     git checkout $OS_ANSIBLE_GIT_VERSION

--- a/config_controller_primary.sh
+++ b/config_controller_primary.sh
@@ -218,9 +218,7 @@ cd ${checkout_dir}/rpc-openstack
 
 # if we want to use a different submodule repo/sha
 if [ ! -z $OS_ANSIBLE_GIT_VERSION ]; then
-  rm .gitmodules
-  git rm openstack-ansible
-  git submodule add %%OS_ANSIBLE_GIT_REPO%%
+  sed -i 's@url = https://git.openstack.org/openstack/openstack-ansible@url = %%OS_ANSIBLE_GIT_REPO%%@' .gitmodules
   git submodule update --init
   pushd openstack-ansible
     git checkout $OS_ANSIBLE_GIT_VERSION


### PR DESCRIPTION
Currently, if someone overrides %%OS_ANSIBLE_GIT_VERSION%%, it removes
.gitmodules and re-adds %%OS_ANSIBLE_GIT_REPO%%.  This is fine, except
there are now additional ceph-related submodules which don't get added
back in.  This commit does a sed in .gitmodules to replace the default
%%OS_ANSIBLE_GIT_REPO%%, which means we can then just 'git submodule
update --init' as you would normally do.
