### PR TITLE
Use git config to override openstack-ansible url

### DIFF
--- a/build/controller_primary.sh
+++ b/build/controller_primary.sh
@@ -31,7 +31,7 @@ cd ${checkout_dir}/rpc-openstack
 
 # if we want to use a different submodule repo/sha
 if [ ! -z $OS_ANSIBLE_GIT_VERSION ]; then
-  sed -i 's@url = https://git.openstack.org/openstack/openstack-ansible@url = %%OS_ANSIBLE_GIT_REPO%%@' .gitmodules
+  git config --file=.gitmodules submodule.openstack-ansible.url %%OS_ANSIBLE_GIT_REPO%%
   git submodule update --init
   pushd openstack-ansible
     git checkout $OS_ANSIBLE_GIT_VERSION

--- a/config_controller_primary.sh
+++ b/config_controller_primary.sh
@@ -218,7 +218,7 @@ cd ${checkout_dir}/rpc-openstack
 
 # if we want to use a different submodule repo/sha
 if [ ! -z $OS_ANSIBLE_GIT_VERSION ]; then
-  sed -i 's@url = https://git.openstack.org/openstack/openstack-ansible@url = %%OS_ANSIBLE_GIT_REPO%%@' .gitmodules
+  git config --file=.gitmodules submodule.openstack-ansible.url %%OS_ANSIBLE_GIT_REPO%%
   git submodule update --init
   pushd openstack-ansible
     git checkout $OS_ANSIBLE_GIT_VERSION


### PR DESCRIPTION
This commit uses git config to update the openstack-ansible url in
.gitmodules, rather than doing the current sed.  See [1] for
conversation where this was suggested.

[1] https://github.com/rcbops/rpc-heat/pull/80
