### PR TITLE
Force neutron_l2_population to True

### DIFF
--- a/build/controller_primary.sh
+++ b/build/controller_primary.sh
@@ -56,6 +56,7 @@ pushd openstack-ansible
 
   echo "nova_virt_type: qemu" >> $user_variables
   echo "keystone_wsgi_processes: 4" >> $user_variables
+  echo "neutron_l2_population: True" >> $user_variables
   sed -i "s/\(glance_default_store\): .*/\1: %%GLANCE_DEFAULT_STORE%%/g" $user_variables
 
   environment_version=$(md5sum ${config_dir}/openstack_environment.yml | awk '{print $1}')


### PR DESCRIPTION
In liberty and mitaka, openstack-ansible defaults neutron_l2_population
to False and enables it when l3ha is enabled (which happens when you
have > 1 neutron agents containers).

We will need to investigate to see how we can use l3ha on our
multi-node deploys, but for now we enable neutron_l2_population so our
instances attached to a tenant network are accessible.
