### PR TITLE
switch to using native neutron resource for networks

### DIFF
--- a/build/all_header.sh
+++ b/build/all_header.sh
@@ -44,7 +44,7 @@ for interface in eth1 eth2 eth3 eth4; do
 done
 
 cat $INTERFACES | while read line; do
-  if echo "$line" | grep "# Label heat_"; then
+  if echo "$line" | egrep "# Label .*%%CLUSTER_PREFIX%%_"; then
     found=1
   fi
 

--- a/config_ceph_all.sh
+++ b/config_ceph_all.sh
@@ -44,7 +44,7 @@ for interface in eth1 eth2 eth3 eth4; do
 done
 
 cat $INTERFACES | while read line; do
-  if echo "$line" | grep "# Label heat_"; then
+  if echo "$line" | egrep "# Label .*%%CLUSTER_PREFIX%%_"; then
     found=1
   fi
 

--- a/config_compute_all.sh
+++ b/config_compute_all.sh
@@ -44,7 +44,7 @@ for interface in eth1 eth2 eth3 eth4; do
 done
 
 cat $INTERFACES | while read line; do
-  if echo "$line" | grep "# Label heat_"; then
+  if echo "$line" | egrep "# Label .*%%CLUSTER_PREFIX%%_"; then
     found=1
   fi
 

--- a/config_controller_other.sh
+++ b/config_controller_other.sh
@@ -44,7 +44,7 @@ for interface in eth1 eth2 eth3 eth4; do
 done
 
 cat $INTERFACES | while read line; do
-  if echo "$line" | grep "# Label heat_"; then
+  if echo "$line" | egrep "# Label .*%%CLUSTER_PREFIX%%_"; then
     found=1
   fi
 

--- a/config_controller_primary.sh
+++ b/config_controller_primary.sh
@@ -44,7 +44,7 @@ for interface in eth1 eth2 eth3 eth4; do
 done
 
 cat $INTERFACES | while read line; do
-  if echo "$line" | grep "# Label heat_"; then
+  if echo "$line" | egrep "# Label .*%%CLUSTER_PREFIX%%_"; then
     found=1
   fi
 

--- a/openstack_multi_node.yml
+++ b/openstack_multi_node.yml
@@ -257,22 +257,49 @@ resources:
       save_private_key: true
 
   heat_mgmt_vxlan:
-    type: Rackspace::Cloud::Network
+    type: OS::Neutron::Net
     properties:
+      name:
+        str_replace:
+          template: stack_mgmt_vxlan
+          params:
+            stack: { get_param: "OS::stack_name" }
+
+  heat_mgmt_vxlan_subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: { get_resource: heat_mgmt_vxlan }
       cidr: 172.29.236.0/22
-      label: heat_mgmt_vxlan
 
   heat_tunnel:
-    type: Rackspace::Cloud::Network
+    type: OS::Neutron::Net
     properties:
+      name:
+        str_replace:
+          template: stack_tunnel
+          params:
+            stack: { get_param: "OS::stack_name" }
+
+  heat_tunnel_subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: { get_resource: heat_tunnel }
       cidr: 172.29.240.0/22
-      label: heat_tunnel
 
   heat_storage:
-    type: Rackspace::Cloud::Network
+    type: OS::Neutron::Net
     properties:
+      name:
+        str_replace:
+          template: stack_storage
+          params:
+            stack: { get_param: "OS::stack_name" }
+
+  heat_storage_subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: { get_resource: heat_storage }
       cidr: 172.29.228.0/22
-      label: heat_storage
 
   controller1:
     type: "OS::Nova::Server"


### PR DESCRIPTION
RS cloud networks team advised we switch to using the native heat resource for neutron networks, as opposed to the Rackspace specific resource. 
