### PR TITLE
Add deprecation notice and link to new templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DEPRECATED
+
+Please use https://github.com/cloud-training/rpc-heat-ansible instead.
+
 **To run:**
 
 ```


### PR DESCRIPTION
This set of heat templates is no longer maintained, but doesn't direct to the new ones. This patch provides a notice for people who may come looking for RPC heat templates.
